### PR TITLE
Update Storybook addon metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
     "storybook-addon",
     "addon",
     "devtools",
-    "graphql-kit"
-  ]
+    "graphql-kit",
+    "data-state"
+  ],
+  "storybook": {
+    "displayName": "GraphQL Kit"
+  }
 }


### PR DESCRIPTION
Hey focusreactive! We've created a catalog of Storybook addons and yours is included: https://storybook.js.org/addons/@focus-reactive/storybook-graphql-kit

To make your addon more discoverable in the catalog, we've curated some of its metadata, and I've included those edits in this PR.

To learn more about the catalog metadata, check out our documentation: https://storybook.js.org/docs/react/addons/addon-catalog
